### PR TITLE
feat: Improve undoRedo logic

### DIFF
--- a/scripts/addText.js
+++ b/scripts/addText.js
@@ -32,10 +32,10 @@ document.getElementById("text-stroke-width")
 function addTextToCanvas(){
     let text = addTextField.value
     function addText(event) {
-        save.saveUndoState();
         ctx.font = `${addTextVars.textSize}px 'serif'`;
         ctx.fillStyle = addTextVars.textColor
         ctx.fillText(text, event.clientX, event.clientY)
+        save.saveState();
         canvas.removeEventListener("click", addText)
     }
     canvas.addEventListener("click", addText)

--- a/scripts/clear-canvas.js
+++ b/scripts/clear-canvas.js
@@ -2,9 +2,11 @@ let clear = document.getElementById("clear-canvasPenbar");
 let cleardef = document.querySelector('#clear-canvasDefbar');
 
 function clearCanvas(){
-    save.saveUndoState();
+    // Nothing to do, we already have a blank canvas
+    if (save.getCurrentState() === save.initial_state) return;
     ctx.fillStyle = pencilBoxVars.backgroundColor;
     ctx.clearRect(0,0, canvas.width, canvas.height);
+    save.saveState();
     ctx.beginPath()
 }
 

--- a/scripts/drawShapes.js
+++ b/scripts/drawShapes.js
@@ -18,7 +18,6 @@ function setLineStart(event) {
     ctx.moveTo(event.clientX, event.clientY)
     ctx.lineTo(event.clientX, event.clientY)
     ctx.stroke()
-    save.saveUndoState();
 }
 
 function showCurrentLine(event) {
@@ -37,7 +36,9 @@ function showCurrentLine(event) {
 }
 
 function drawLine(event) {
+    if (!painting) return;
     painting = false;
+    save.saveState();
 }
 
 function setRectStart(event) {
@@ -51,7 +52,6 @@ function setRectStart(event) {
     ctx.moveTo(event.clientX, event.clientY)
     ctx.rect(shapeDrawVars.startX, shapeDrawVars.startY, event.clientX - shapeDrawVars.startX, event.clientY - shapeDrawVars.startY)
     ctx.stroke()
-    save.saveUndoState();
 }
 
 function showCurrentRect(event) {
@@ -70,7 +70,9 @@ function showCurrentRect(event) {
 }
 
 function drawRect(event) {
+    if (!painting) return;
     painting = false;
+    save.saveState();
 }
 
 function setCircleStart(event) {
@@ -88,7 +90,6 @@ function setCircleStart(event) {
     ctx.moveTo(length + shapeDrawVars.startX, shapeDrawVars.startY)
     ctx.arc(shapeDrawVars.startX, shapeDrawVars.startY, radius, 0, 2 * Math.PI)
     ctx.stroke()
-    save.saveUndoState();
 }
 
 function showCurrentCircle(event) {
@@ -111,7 +112,9 @@ function showCurrentCircle(event) {
 }
 
 function drawCircle(event) {
+    if (!painting) return;
     painting = false;
+    save.saveState();
 }
 
 function setTriangleStart(event) {
@@ -122,7 +125,6 @@ function setTriangleStart(event) {
     ctx.beginPath()
     ctx.lineWidth = shapeDrawVars.strokeWidth
     ctx.strokeStyle = shapeDrawVars.strokeColor
-    save.saveUndoState();
 }
 
 function showCurrentTriangle(event) {
@@ -147,7 +149,9 @@ function showCurrentTriangle(event) {
 }
 
 function drawTriangle(event) {
+    if (!painting) return;
     painting = false;
+    save.saveState();
 }
 
 for (let addShapeButton of addShapeButtons) {

--- a/scripts/insert-image.js
+++ b/scripts/insert-image.js
@@ -10,13 +10,13 @@ function insertImage(event){
                 let imgDrawListener = function(e) {
                     let [x, y] = getLocation(canvas, e);
                     ctx.drawImage(image,x,y);
+                    save.saveState();
                     canvas.removeEventListener('click', imgDrawListener);
                 }
                 canvas.addEventListener('click', imgDrawListener)
             }
         }
         reader.readAsDataURL(file);
-        save.saveUndoState();
     }
 }
 

--- a/scripts/multiboard.js
+++ b/scripts/multiboard.js
@@ -11,28 +11,27 @@ closeBtn.addEventListener("click", function () {
 
 let currentBoardIndex = 0;
 let boardStore = [];
-let boardTemplate = function (board, boardUndoList, boardRedoList) {
+const newBoardTemplate = function () {
   return {
-    board,
-    boardUndoList,
-    boardRedoList,
+    board: canvas.toDataURL(),
+    state_history: [canvas.toDataURL()],
+    current_offset: 0,
   };
 };
-
 function initMultiBoardDrawer() {
-  boardStore.push(boardTemplate(canvas.toDataURL(), [], []));
+  boardStore.push(newBoardTemplate());
   createNewBoardAtTheEnd();
 }
 
 function loadCurrentBoardHistory() {
-  save.undo_list = boardStore[currentBoardIndex].boardUndoList;
-  save.redo_list = boardStore[currentBoardIndex].boardRedoList;
+  save.state_history = boardStore[currentBoardIndex].state_history;
+  save.current_offset = boardStore[currentBoardIndex].current_offset;
 }
 
 function saveCurrentBoard() {
   boardStore[currentBoardIndex].board = canvas.toDataURL();
-  boardStore[currentBoardIndex].boardUndoList = save.undo_list;
-  boardStore[currentBoardIndex].boardRedoList = save.redo_list;
+  boardStore[currentBoardIndex].state_history = save.state_history;
+  boardStore[currentBoardIndex].current_offset = save.current_offset;
 
   const selectedBoard = document.querySelector("div.thumbnail.selected");
   selectedBoard.children[0].src = boardStore[currentBoardIndex].board;
@@ -42,8 +41,8 @@ function addBoard() {
   saveCurrentBoard();
 
   ctx.clearRect(0, 0, canvas.width, canvas.height);
-  let newBoard = boardTemplate(canvas.toDataURL(), [], []);
-  boardStore.push(newBoard);
+  current_state = canvas.toDataURL()
+  boardStore.push(newBoardTemplate());
 
   currentBoardIndex = boardStore.length - 1;
 
@@ -83,11 +82,11 @@ function selectBoard(boardIndex) {
 function createNewBoardAtTheEnd() {
  const selectedBoard = document.querySelector("div.thumbnail.selected");
 
-  if (selectedBoard !== null) 
+  if (selectedBoard !== null)
     selectedBoard.classList.remove("selected");
-  
+
   const boardIndex = boardStore.length - 1;
-  let boardPreview = boardStore[boardIndex];
+  let boardPreview = boardStore[boardIndex].board;
 
   let thumbnail_group = document.createElement("div");
   let number = document.createElement("div");
@@ -102,7 +101,7 @@ function createNewBoardAtTheEnd() {
 
   number.innerHTML = boardIndex + 1;
 
-  previewImg.src = boardPreview.board;
+  previewImg.src = boardPreview;
   previewImg.style.backgroundColor = colorPickerBackground.value
 
   thumbnail.thumbIndex = boardIndex;

--- a/scripts/pencilBox.js
+++ b/scripts/pencilBox.js
@@ -23,12 +23,14 @@ function addPenOneEvents() {
         ctx.stroke();
     }
     onMouseDownEvent = function() {
+        if (pencilBoxVars.painting) return;
         pencilBoxVars.painting = true;
         ctx.beginPath();
-        save.saveUndoState();
     }
     onMouseUpEvent = function() {
+        if (!pencilBoxVars.painting) return;
         pencilBoxVars.painting = false;
+        save.saveState();
     }
     addAllEvents();
 }
@@ -46,10 +48,10 @@ function addPenTwoEvents() {
     onMouseDownEvent = function() {
         pencilBoxVars.painting = true;
         ctx.beginPath();
-        save.saveUndoState();
     }
     onMouseUpEvent = function() {
         pencilBoxVars.painting = false;
+        save.saveState();
     }
     addAllEvents();
 }
@@ -67,10 +69,10 @@ function addHighlighterEvents() {
     onMouseDownEvent = function() {
         pencilBoxVars.painting = true;
         ctx.beginPath();
-        save.saveUndoState();
     }
     onMouseUpEvent = function() {
         pencilBoxVars.painting = false;
+        save.saveState();
     }
     addAllEvents();
 }
@@ -85,7 +87,6 @@ function addEraserEvents() {
     }
     onMouseDownEvent = function() {
         pencilBoxVars.painting = true;
-        save.saveUndoState();
         ctx.beginPath();
         ctx.lineWidth = pencilBoxVars.eraserWidth;
         ctx.lineCap = 'round';
@@ -94,6 +95,7 @@ function addEraserEvents() {
     onMouseUpEvent = function() {
         ctx.globalCompositeOperation="source-over";
         pencilBoxVars.painting = false;
+        save.saveState();
     }
     addAllEvents();
 }

--- a/scripts/undoRedo.js
+++ b/scripts/undoRedo.js
@@ -2,28 +2,35 @@ let undoBtn = document.getElementById('undo')
 let redoBtn = document.getElementById('redo')
 let canvasContainer = document.getElementById('canvas-container');
 let save = {
-    redo_list: [],
-    undo_list: [],
-    saveUndoState: function() {
+    initial_state: canvas.toDataURL(),
+    state_history: [],
+    current_offset: 0,
+    saveState() {
         let save_point = canvas.toDataURL()
-        this.undo_list.push(save_point)
+        // No need to push the state if it hasn't changed
+        if (this.getCurrentState() === save_point) return;
+
+        this.current_offset += 1
+        // We have to erase the redo history after, since it has become outdated
+        this.state_history = this.state_history.slice(0, this.current_offset)
+        this.state_history.push(save_point)
     },
-    saveRedoState: function() {
-        let save_point = canvas.toDataURL()
-        this.redo_list.push(save_point)
+    getCurrentState() {
+        return this.state_history[this.current_offset];
     },
-    redoErase: function() {
-        this.redo_list = []
+    clearStateHistory() {
+        this.state_history = [this.initial_state]
     }
 }
+save.state_history.push(save.initial_state) //We want a blank board as initial undo
 
 function undo() {
-    if (save.undo_list.length === 0)
+    if (save.current_offset <= 0)
         window.alert("NOTHING TO UNDO YOU FOOL")
     else {
-        save.saveRedoState();
-        let restored_state = save.undo_list.pop()
-        let image = document.createElement('img')
+        save.current_offset -= 1
+        const restored_state = save.getCurrentState()
+        const image = document.createElement('img')
         image.src = restored_state;
         image.onload = function() {
             ctx.clearRect(0, 0, canvas.width, canvas.height)
@@ -33,12 +40,13 @@ function undo() {
 }
 
 function redo() {
-    if (save.redo_list.length === 0)
+    // if current_offset == state_history.length, we are already at the latest state
+    if (save.current_offset >= (save.state_history.length - 1))
         window.alert("NOTHING TO REDO YOU FOOL")
     else {
-        save.saveUndoState();
-        let restored_state = save.redo_list.pop();
-        let image = document.createElement('img')
+        save.current_offset += 1
+        const restored_state = save.getCurrentState()
+        const image = document.createElement('img')
         image.src = restored_state;
         image.onload = function() {
             ctx.clearRect(0, 0, canvas.width, canvas.height)


### PR DESCRIPTION
Change the logic of undoRedo to be able to save the state at the end of the draw action (mouseup).
Should also slightly improve performances.

Fixes #12