### PR TITLE
Issue #21: Fix rotating "Shapes Palette" label

### DIFF
--- a/styles/Dock.css
+++ b/styles/Dock.css
@@ -94,7 +94,7 @@
 .clear{
     animation: delete .3s ease infinite;
 }
-#shapes:hover{
+#shapes:hover .fa-shapes{
     animation: rotate 1s ease infinite;
 }
 @keyframes cursorblink {


### PR DESCRIPTION
Adding .fa-shapes to the #shapes:hover so the animation only plays for the icon.

![shapes_rotate_correct](https://user-images.githubusercontent.com/16044116/135848529-a03ccbe2-4e15-4605-ad5a-db9807cd5ab2.gif)


Fix issue https://github.com/untitled-team-101/Whiteboard/issues/21